### PR TITLE
Fix ModuleNotFoundError: No module named 'assets'

### DIFF
--- a/friTap/android.py
+++ b/friTap/android.py
@@ -82,7 +82,7 @@ class Android:
 
 
     def _get_tcpdump_version(self):
-        tcpdump_path = files('assets.tcpdump_binaries').joinpath(self.tcpdump_version)
+        tcpdump_path = files('friTap.assets.tcpdump_binaries').joinpath(self.tcpdump_version)
 
         if file_exists(tcpdump_path):
             return tcpdump_path


### PR DESCRIPTION
Trying to launch --full_capture raises a module not found error.