### PR TITLE
update ios boringssl to support iOS15

### DIFF
--- a/agent/ios/openssl_boringssl_ios.ts
+++ b/agent/ios/openssl_boringssl_ios.ts
@@ -14,9 +14,12 @@ export class OpenSSL_BoringSSL_iOS extends OpenSSL_BoringSSL {
             if(foundationNumber == undefined){
                 devlog("Installing callback for iOS < 14");
                 CALLBACK_OFFSET = 0x2A8;
-            } else if (foundationNumber >= 1751.108 && foundationNumber < 1946.102) {
+            } else if (foundationNumber >= 1751.108 && foundationNumber < 1854) {
                 devlog("Installing callback for iOS >= 14");
                 CALLBACK_OFFSET = 0x2B8; // >= iOS 14.x 
+            } else if (foundationNumber >= 1854 && foundationNumber < 1946.102) {
+                devlog("Installing callback for iOS >= 15");
+                CALLBACK_OFFSET = 0x2F8; // >= iOS 15.x 
             } else if (foundationNumber >= 1946.102 && foundationNumber <= 1979.1) {
                 devlog("Installing callback for iOS >= 16");
                 CALLBACK_OFFSET = 0x300; // >= iOS 16.x 


### PR DESCRIPTION
iOS15 was not hooking properly, funny enough, https://github.com/fkie-cad/friTap/pull/16 used a repo that has the correct offset for iOS15, but to fix 16 and 17 and let the 15 wrong 🙈, with this fix it works for iOS 15 as well, I've confirmed within my phone!