### PR TITLE
fix: handle multiple PIDs for terminating tcpdump processes.

### DIFF
--- a/friTap/android.py
+++ b/friTap/android.py
@@ -141,37 +141,49 @@ class Android:
     def get_pid_via_adb(self, process_name):
         try:
             pid_result =self.run_adb_command_as_root(f"pidof -s {process_name}")
-            pid = pid_result.stdout.strip()
+            pids = pid_result.stdout.strip().split()
 
-            if not pid:
+            if not pids:
                 if self.print_debug_infos:
                     print("[-] No PID found. Process may not be running.")
-                return "-1"
-            return pid
+                return []
+            return pids
         except subprocess.CalledProcessError as e:
             if self.print_debug_infos:
                 print(f"Error: {e.stderr.strip()}")
-            return "-1"
+            return []
             
     def send_ctrlC_over_adb(self):
         self.close_friTap_if_none_android()
         if self.is_tcpdump_available():
-            pid = self.get_pid_via_adb("tcpdump")
+            pids = self.get_pid_via_adb("tcpdump")
         else:
-            pid = self.get_pid_via_adb(self.tcpdump_version)
-        
-        if int(pid) > 0:
-            self.run_adb_command_as_root(f"kill -INT {pid}")
+            pids = self.get_pid_via_adb(self.tcpdump_version)
+
+        if pids:
+            pids_str = " ".join(pids)
+            self.run_adb_command_as_root(f"kill -INT {pids_str}")
+            if self.print_debug_infos:
+                print(f"[+] Killed processes with PID: {pids_str}")
+        else:
+            if self.print_debug_infos:
+                print("[-] No running tcpdump processes found")
 
     def send_kill_tcpdump_over_adb(self):
         self.close_friTap_if_none_android()
         if self.is_tcpdump_available():
-            pid = self.get_pid_via_adb("tcpdump")
+            pids = self.get_pid_via_adb("tcpdump")
         else:
-            pid = self.get_pid_via_adb(self.tcpdump_version)
+            pids = self.get_pid_via_adb(self.tcpdump_version)
         
-        if int(pid) > 0:
-            self.run_adb_command_as_root(f"kill -9 {pid}")
+        if pids:
+            pids_str = " ".join(pids)
+            self.run_adb_command_as_root(f"kill -9 {pids_str}")
+            if self.print_debug_infos:
+                print(f"[+] Killed processes with PID: {pids_str}")
+        else:
+            if self.print_debug_infos:
+                print("[-] No running tcpdump processes found")
         
     def close_friTap_if_none_android(self):
         if self.is_Android == False:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scapy
 watchdog
 click
 importlib-resources
+psutil

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ requirements = [
     'scapy',
     'watchdog',
     'click',
-    'importlib-resources'
+    'importlib-resources',
+    'psutil'
 ]
 
 


### PR DESCRIPTION
fix: handle multiple PIDs for terminating tcpdump processes.
fix: add 'psutil' as a dependency for its usage in pcap.py.
---

in some cases a 'clean up' is not done properly leading to not closing all 'tcpdump' processes, so running friTap again will always case issue as 'get_pid_via_adb' function will return multiple PIDs.
```[*] Ctrl+C detected. Cleaning up...

[-] Unknown error: invalid literal for int() with base 10: '8775 19286 20395 20550 21516 23020 23111 23202 23392 23510 23600 23877 23969'
Traceback (most recent call last):
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\site-packages\friTap\friTap.py", line 122, in main
    while ssl_log.running:
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\site-packages\friTap\ssl_logger.py", line 633, in signal_handler
    self.pcap_cleanup(self.full_capture, self.mobile, self.pcap_name)
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\site-packages\friTap\ssl_logger.py", line 563, in pcap_cleanup
    self.pcap_obj.full_capture_thread.join(2.0)
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\site-packages\friTap\pcap.py", line 173, in join
    pcap_class.android_Instance.send_ctrlC_over_adb()
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\site-packages\friTap\android.py", line 159, in send_ctrlC_over_adb
    pid = self.get_pid_via_adb("tcpdump")
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\site-packages\friTap\android.py", line 143, in get_pid_via_adb
    pid_result =self.run_adb_command_as_root(f"pidof -s {process_name}")
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\site-packages\friTap\android.py", line 42, in run_adb_command_as_root
    output = subprocess.run(['adb', 'shell','su -c '+command], capture_output=True, text=True)
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\subprocess.py", line 505, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\subprocess.py", line 1154, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\subprocess.py", line 1528, in _communicate
    self.stdout_thread.join(self._remaining_time(endtime))
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\threading.py", line 1096, in join
    self._wait_for_tstate_lock()
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\threading.py", line 1116, in _wait_for_tstate_lock
    if lock.acquire(block, timeout):
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\site-packages\friTap\ssl_logger.py", line 568, in pcap_cleanup
    self.pcap_obj.android_Instance.send_ctrlC_over_adb()
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\site-packages\friTap\android.py", line 37, in run_adb_command_as_root
    if self.adb_check_root() == False:
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\site-packages\friTap\android.py", line 30, in adb_check_root
    if bool(subprocess.run(['adb', 'shell','su -v'], capture_output=True, text=True).stdout):
  File "C:\Users\hakeem\AppData\Local\Programs\Python\Python310\lib\site-packages\friTap\android.py", line 163, in send_ctrlC_over_adb
    if int(pid) > 0:
```

also after installing friTap 'psutil' dependency is not installed
![image](https://github.com/user-attachments/assets/bdf4e878-8f6c-4850-88f6-a0bfbf940d69)

