### PR TITLE
fix goTLS datalog messages (buffer as second argument)

### DIFF
--- a/agent/ssl_lib/gotls.ts
+++ b/agent/ssl_lib/gotls.ts
@@ -509,8 +509,7 @@ export class GoTLS {
                         send({
                             contentType: "datalog",
                             function: "SSL_write",
-                            data: buf
-                        });
+                        }, buf);
                     }
                 }
             });
@@ -545,8 +544,7 @@ export class GoTLS {
                     send({
                         contentType: "datalog",
                         function: "SSL_read",
-                        data: buf
-                    });
+                    }, buf);
                 }
             });
             this.hooked_functions.add(symbol);


### PR DESCRIPTION
As for all other TLS libraries buffer data should be the second argument of Frida send function, not a key within sent payload.